### PR TITLE
allow unix times before year 2001

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@
 	PATTERNS.relative = /^\d+ms|[smhdwmny]\-ago/;
 
 	// Seconds or milliseconds; e.g., Date.now():
-	PATTERNS.timestamp = /^\d{10}$|^\d{13}$/;
+	PATTERNS.timestamp = /^\d{1,13}$/;
 
 
 	// VALIDATE //

--- a/test/test.js
+++ b/test/test.js
@@ -147,8 +147,6 @@ describe( 'validate', function tests() {
 		it( 'should properly validate a timestamp', function test() {
 			assert.ok( validate.timestamp( Date.now() ) );
 			assert.ok( validate.timestamp( Math.round( Date.now()/1000 ) ) ); // seconds
-
-			assert.notOk( validate.timestamp( 45 ) );
 		});
 
 	}); // end TESTS timestamp
@@ -204,7 +202,6 @@ describe( 'validate', function tests() {
 			assert.strictEqual( validate.format( Date.now() ), 'timestamp' );
 			assert.strictEqual( validate.format( Math.round( Date.now()/1000 ) ), 'timestamp' );
 			
-			assert.notEqual( validate.format( 45 ), 'timestamp' );
 			assert.notEqual( validate.format( '8m-ago' ), 'timestamp' );
 			assert.notEqual( validate.format( '2014/08/02 09:45' ), 'timestamp' );
 		});


### PR DESCRIPTION
It's useful for users to be able to query any unix time, not simply after year 2001. Also it's useful for `0` to be an available start time.
